### PR TITLE
Single socket fix

### DIFF
--- a/BLClient.java
+++ b/BLClient.java
@@ -28,7 +28,7 @@ class Message {
     }
 }
 
-public class JavaNetClientV2 {
+public class BLClient {
 
     final static int PORT = 11122;
     final static int CHUNK_SIZE = 1024;

--- a/BLServer.java
+++ b/BLServer.java
@@ -43,8 +43,10 @@ class ClientHandler implements Runnable {
 	}
 
 	/**
+	 * Performs a GET request to the specified web server by the client
+	 * Redirects are followed automatically
 	 * 
-	 * @return
+	 * @return byte[] The response body from the web server
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
@@ -65,6 +67,7 @@ class ClientHandler implements Runnable {
 	}
 
 	/**
+	 * Adds the ACK packet to the datagram queue for processing.
 	 * 
 	 * @param ackPacket
 	 */

--- a/BLServer.java
+++ b/BLServer.java
@@ -163,12 +163,12 @@ class ClientHandler implements Runnable {
 		} catch (IOException | InterruptedException e) {
 			e.printStackTrace();
 		} finally {
-			NetServerV2.removeClient(clientPort);
+			BLServer.removeClient(clientPort);
 		}
 	}
 }
 
-public class NetServerV2 {
+public class BLServer {
 
 	// Map to hold client handlers by their port number
 	private static final ConcurrentHashMap<Integer, ClientHandler> clientHandlers = new ConcurrentHashMap<>();

--- a/JavaNetClientV2.java
+++ b/JavaNetClientV2.java
@@ -1,7 +1,7 @@
-import java.util.Scanner;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.Scanner;
 
 public class JavaNetClientV2 {
 

--- a/JavaNetClientV2.java
+++ b/JavaNetClientV2.java
@@ -1,49 +1,101 @@
 import java.io.*;
 import java.net.*;
+import java.nio.ByteBuffer;
+import java.util.Scanner;
+
+class Message {
+    private int seqNum;
+    private int length;
+    private String payload;
+
+    public int getSeqNum() {
+        return seqNum;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public Message(int seqNum, String payload) {
+        this.seqNum = seqNum;
+        this.payload = payload;
+        this.length = payload.length();
+    }
+}
 
 public class JavaNetClientV2 {
-    public static void main(String args[]) throws Exception {
 
-        //create input stream
-        // TODO: Use Scanner as this is too simple of an input
-        BufferedReader inFromUser = new BufferedReader(new InputStreamReader(System.in));
+    final static int PORT = 11122;
+    final static int CHUNK_SIZE = 1024;
+    static DatagramSocket clientSocket;
+    static InetAddress SERVER_ADDRESS;
+    static Scanner scanner;
 
-        //translate hostname to IP address
-        InetAddress IPAddress = InetAddress.getByName("localhost");
+    public static void sendWebAddressToServer(String webAddress) throws IOException {
+        byte[] webServerURL = new byte[CHUNK_SIZE];
+        webServerURL = webAddress.getBytes();
+        DatagramPacket webServerPacket = new DatagramPacket(webServerURL, webServerURL.length, SERVER_ADDRESS, PORT);
 
-        // Use a const
-        byte[] sendData = new byte[1024];
-        byte[] receiveData = new byte[1024];
+        // send datagram to server
+        clientSocket.send(webServerPacket);
+    }
 
-        System.out.print("Enter a web address: ");
-        String sentence = inFromUser.readLine();
-        sendData = sentence.getBytes();
-
-        //create datagram with data to send
-        // TODO: Avoid magic number on port. Use a variable name
-        DatagramPacket sendPacket = new DatagramPacket(sendData, sendData.length, IPAddress, 11122);
-
-        //create client socket
-        DatagramSocket clientSocket = new DatagramSocket();
-        //send datagram to server
-        clientSocket.send(sendPacket);
-
-        //read datagram from server
-        DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
-
+    public static Message receiveResponseFromServer() throws IOException {
+        // Receive the response from the server
+        // Sequence number + payload length + payload
+        byte[] receivedData = new byte[(Integer.BYTES * 2) + CHUNK_SIZE];
+        DatagramPacket receivePacket = new DatagramPacket(receivedData, receivedData.length);
         clientSocket.receive(receivePacket);
-        
-        String modifiedSentence =
-                new String(
-                           // byte []
-                           receivePacket.getData(),
-                           // offset
-                           0,
-                           // length
-                           receivePacket.getLength());
 
-        System.out.println("FROM SERVER: " + modifiedSentence);
+        ByteBuffer serverBuffer = ByteBuffer.wrap(receivePacket.getData(), 0, receivePacket.getLength());
 
-        clientSocket.close();
+        return new Message(
+                // sequence number
+                serverBuffer.getInt(),
+                // payload
+                new String(serverBuffer.array(), serverBuffer.position(), serverBuffer.remaining()));
+    }
+
+    public static void main(String args[]) throws Exception {
+        clientSocket = new DatagramSocket();
+        SERVER_ADDRESS = InetAddress.getLocalHost();
+        scanner = new Scanner(System.in);
+        System.out.print("Enter a web address: ");
+        String webAddress = scanner.nextLine();
+        scanner.close();
+
+        sendWebAddressToServer(webAddress);
+        boolean fullResReceived = false;
+        ByteArrayOutputStream fullRes = new ByteArrayOutputStream();
+        while (!fullResReceived) {
+            Message msg = receiveResponseFromServer();
+            System.out.println(
+                    "Received chunk with sequence number: " + msg.getSeqNum() + ", length: " + msg.getLength());
+            // Accumulate each chunk of the response
+            fullRes.write(msg.getPayload().getBytes());
+
+            // Allocate a buffer for the ACK
+            ByteBuffer ackBuffer = ByteBuffer.allocate(Integer.BYTES);
+            // Return an alternate sequence number
+            ackBuffer.putInt(msg.getSeqNum() ^ 1);
+            DatagramPacket ackPacket = new DatagramPacket(
+                    ackBuffer.array(),
+                    Integer.BYTES,
+                    SERVER_ADDRESS,
+                    PORT);
+
+            // Send ACK back to server
+            clientSocket.send(ackPacket);
+
+            if (msg.getLength() < CHUNK_SIZE) {
+                fullResReceived = true;
+            }
+        }
+
+        // clientSocket.close();
     }
 }

--- a/JavaNetClientV2.java
+++ b/JavaNetClientV2.java
@@ -47,11 +47,12 @@ public class JavaNetClientV2 {
     public static Message receiveResponseFromServer() throws IOException {
         // Receive the response from the server
         // Sequence number + payload length + payload
-        byte[] receivedData = new byte[(Integer.BYTES * 2) + CHUNK_SIZE];
-        DatagramPacket receivePacket = new DatagramPacket(receivedData, receivedData.length);
-        clientSocket.receive(receivePacket);
+        byte[] datagramBuffer = new byte[(Integer.BYTES * 2) + CHUNK_SIZE];
+        DatagramPacket datagramFromServer = new DatagramPacket(datagramBuffer, datagramBuffer.length);
+        clientSocket.receive(datagramFromServer);
+        System.out.println(clientSocket.getPort());
 
-        ByteBuffer serverBuffer = ByteBuffer.wrap(receivePacket.getData(), 0, receivePacket.getLength());
+        ByteBuffer serverBuffer = ByteBuffer.wrap(datagramFromServer.getData(), 0, datagramFromServer.getLength());
 
         return new Message(
                 // sequence number
@@ -80,8 +81,9 @@ public class JavaNetClientV2 {
 
             // Allocate a buffer for the ACK
             ByteBuffer ackBuffer = ByteBuffer.allocate(Integer.BYTES);
-            // Return an alternate sequence number
+            // Return an ACK datagram with an alternate sequence number
             ackBuffer.putInt(msg.getSeqNum() ^ 1);
+
             DatagramPacket ackPacket = new DatagramPacket(
                     ackBuffer.array(),
                     Integer.BYTES,
@@ -95,7 +97,6 @@ public class JavaNetClientV2 {
                 fullResReceived = true;
             }
         }
-
-        // clientSocket.close();
+        clientSocket.close();
     }
 }

--- a/JavaNetClientV2.java
+++ b/JavaNetClientV2.java
@@ -1,30 +1,49 @@
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.util.Scanner;
+import java.io.*;
+import java.net.*;
 
 public class JavaNetClientV2 {
+    public static void main(String args[]) throws Exception {
 
-    final static String HOST = "127.0.0.1";
-    final static int PORT = 11122;
+        //create input stream
+        // TODO: Use Scanner as this is too simple of an input
+        BufferedReader inFromUser = new BufferedReader(new InputStreamReader(System.in));
 
-    public static void main(String[] args) {
-        Scanner myScanner = new Scanner(System.in);
-        System.out.println("Enter a web address");
-        String webServer = myScanner.nextLine();
-        myScanner.close();
+        //translate hostname to IP address
+        InetAddress IPAddress = InetAddress.getByName("localhost");
 
-        try (Socket client = new Socket()) {
-            client.connect(new InetSocketAddress(HOST, PORT));
-            byte[] buffer = new byte[1024];
-            int bytesRead = client.getInputStream().read(buffer);
-            if (bytesRead > 0) {
-                System.out.println("Received: " + new String(buffer, 0, bytesRead));
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        // Use a const
+        byte[] sendData = new byte[1024];
+        byte[] receiveData = new byte[1024];
 
-        System.out.println("Client: Disconnected from Server");
+        System.out.print("Enter a web address: ");
+        String sentence = inFromUser.readLine();
+        sendData = sentence.getBytes();
+
+        //create datagram with data to send
+        // TODO: Avoid magic number on port. Use a variable name
+        DatagramPacket sendPacket = new DatagramPacket(sendData, sendData.length, IPAddress, 11122);
+
+        //create client socket
+        DatagramSocket clientSocket = new DatagramSocket();
+        //send datagram to server
+        clientSocket.send(sendPacket);
+
+        //read datagram from server
+        DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
+
+        clientSocket.receive(receivePacket);
+        
+        String modifiedSentence =
+                new String(
+                           // byte []
+                           receivePacket.getData(),
+                           // offset
+                           0,
+                           // length
+                           receivePacket.getLength());
+
+        System.out.println("FROM SERVER: " + modifiedSentence);
+
+        clientSocket.close();
     }
 }

--- a/NetServerV2.java
+++ b/NetServerV2.java
@@ -1,55 +1,100 @@
-import java.util.Scanner;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import java.io.*;
+import java.net.*;
+import java.util.Arrays;
 
-public class NetServerV2 extends Thread {
 
-	final static String HOST = "127.0.0.1";
-	final static int PORT = 11122;
+public class NetServerV2 {
+    public static void main(String[] args) throws Exception {
 
-	public static String sendGetRequests(String webServer) throws IOException, InterruptedException {
-		try (HttpClient client = HttpClient.newHttpClient()) {
-			HttpRequest req = HttpRequest.newBuilder()
-					.uri(URI.create(webServer))
-					.build();
+        DatagramSocket serverSocket = new DatagramSocket(11122);
 
-			HttpResponse<String> res = client.send(req, HttpResponse.BodyHandlers.ofString());
-			return res.body();
+        byte[] receiveData = new byte[1024];
+        byte[] sendData = new byte[1024];
+
+        while (true) {
+            //wait for message
+            DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
+            serverSocket.receive(receivePacket);
+
+            //get client input
+            String webAddress = new String(receivePacket.getData(), 0, receivePacket.getLength());
+            System.out.println("Received: " + webAddress);
+
+			new Thread(new ClientHandler(webAddress, receivePacket.getAddress(), receivePacket.getPort())).start();
 		}
-	}
-
-	public static void main(String[] args) {
-		Scanner myScanner = new Scanner(System.in);
-		int timeout = 5;
-
-		try {
-			System.out.println(sendGetRequests("https://www.reddit.com/"));
-		} catch (IOException e) {
-			e.printStackTrace();
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-
-		try {
-			ServerSocket serverSocket = new ServerSocket();
-			serverSocket.bind(new InetSocketAddress(HOST, PORT));
-
-			while (true) {
-				Socket clientSocket = serverSocket.accept();
-				// clientSocket.getOutputStream().write(sendGet.getBytes());
-				clientSocket.close();
-				serverSocket.close();
-				System.exit(0);
-			}
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		myScanner.close();
 	}
 }
+
+class ClientHandler implements Runnable{
+	private String webAddress;
+	private InetAddress clientIP;
+	private int clientPort;
+
+	public ClientHandler(String webAddress, InetAddress clientIP, int clientPort){
+		this.webAddress = webAddress;
+		this.clientIP = clientIP;
+		this.clientPort = clientPort;
+	}
+	@Override
+	public void run(){
+		try {
+			// fetch html content from web address
+			// TODO: Break into a separate function that returns the body
+			URL url = new URL("https://" + webAddress);
+			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+			conn.setRequestMethod("GET");
+
+			//read response
+			InputStream inputStream = conn.getInputStream();
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			byte[] chunk = new byte[1024];
+			int bytesRead;
+			//read in chunks
+			while((bytesRead = inputStream.read(chunk)) != -1){
+				buffer.write(chunk, 0, bytesRead);
+			}
+			byte[] fullPage = buffer.toByteArray();
+			System.out.println("Fetched " +  fullPage.length + " bytes from " + webAddress);
+
+			DatagramSocket socket = new DatagramSocket();
+			int chunkSize = 1024; 
+			int totalBytes = fullPage.length;
+			int offset = 0;
+
+			//loop until all bytes sent
+			while(offset < totalBytes){
+
+				int bytesRemaining = totalBytes - offset;
+				int currentChunkSize = Math.min(chunkSize, bytesRemaining);
+
+				//extract chunk to send in this packet
+				byte[] payload = Arrays.copyOfRange(fullPage, offset, offset + currentChunkSize);
+
+				//create packet with chunk 
+				DatagramPacket packet = new DatagramPacket(payload, payload.length, clientIP, clientPort);
+
+				// Send out to client
+				socket.send(packet);
+
+				System.out.println("Sent chunk " + (offset / chunkSize + 1));
+				offset += currentChunkSize;
+
+				try {
+    				Thread.sleep(30);
+				} 
+				catch (InterruptedException e) {
+    				e.printStackTrace();
+				}
+
+			}
+		
+			System.out.println("Sent entire page to client" + fullPage.length + " bytes");
+
+			socket.close();
+		}
+		catch (IOException e){
+			System.err.print("Error: " + e.getMessage());
+		}
+	}
+}
+			  

--- a/NetServerV2.java
+++ b/NetServerV2.java
@@ -3,15 +3,38 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 public class NetServerV2 extends Thread {
 
 	final static String HOST = "127.0.0.1";
 	final static int PORT = 11122;
 
+	public static String sendGetRequests(String webServer) throws IOException, InterruptedException {
+		try (HttpClient client = HttpClient.newHttpClient()) {
+			HttpRequest req = HttpRequest.newBuilder()
+					.uri(URI.create(webServer))
+					.build();
+
+			HttpResponse<String> res = client.send(req, HttpResponse.BodyHandlers.ofString());
+			return res.body();
+		}
+	}
+
 	public static void main(String[] args) {
 		Scanner myScanner = new Scanner(System.in);
 		int timeout = 5;
+
+		try {
+			System.out.println(sendGetRequests("https://www.reddit.com/"));
+		} catch (IOException e) {
+			e.printStackTrace();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
 
 		try {
 			ServerSocket serverSocket = new ServerSocket();
@@ -19,7 +42,7 @@ public class NetServerV2 extends Thread {
 
 			while (true) {
 				Socket clientSocket = serverSocket.accept();
-				clientSocket.getOutputStream().write("Hello Client".getBytes());
+				// clientSocket.getOutputStream().write(sendGet.getBytes());
 				clientSocket.close();
 				serverSocket.close();
 				System.exit(0);

--- a/NetServerV2.java
+++ b/NetServerV2.java
@@ -50,10 +50,9 @@ class ClientHandler implements Runnable {
 		int chunkSize = 1024;
 		int totalBytes = data.length;
 		int offset = 0;
+		int seqNum = 0;
 
-		System.out.println();
 		while (offset < totalBytes) {
-			int seqNum = 0;
 			int bytesRemaining = totalBytes - offset;
 			int currentChunkSize = Math.min(chunkSize, bytesRemaining);
 
@@ -96,7 +95,7 @@ class ClientHandler implements Runnable {
 						receivedAck = true;
 						offset += currentChunkSize;
 						// Alternate sequence number for next chunk
-						seqNum = seqNum ^ 1;
+						seqNum ^= 1;
 					} else {
 						System.out.println("ACK mismatch. Resending chunk " + (offset / chunkSize + 1));
 					}

--- a/NetServerV2.java
+++ b/NetServerV2.java
@@ -67,7 +67,6 @@ class ClientHandler implements Runnable {
 			buffer.putInt(seqNum);
 			buffer.putInt(payload.length);
 			buffer.put(payload);
-
 			// create packet with a chunk of res.body of size currentChunkSize
 			DatagramPacket packet = new DatagramPacket(
 					buffer.array(),
@@ -78,7 +77,7 @@ class ClientHandler implements Runnable {
 			boolean receivedAck = false;
 			while (!receivedAck) {
 				// Send out to client
-				this.socket.send(packet);
+				socket.send(packet);
 
 				// Wait for ACK from client, which is an int of 4 bytes
 				byte[] ackBuffer = new byte[4];
@@ -87,7 +86,7 @@ class ClientHandler implements Runnable {
 						ackBuffer.length);
 
 				try {
-					this.socket.receive(ackPacket);
+					socket.receive(ackPacket);
 					ByteBuffer ackByteBuffer = ByteBuffer.wrap(ackPacket.getData());
 					int clientSeqNum = ackByteBuffer.getInt();
 
@@ -144,7 +143,7 @@ public class NetServerV2 {
 				DatagramPacket clientPacket = new DatagramPacket(receiveData, receiveData.length);
 				// Anticipate client request
 				serverSocket.receive(clientPacket);
-
+				System.out.println(clientPacket.getPort());
 				// byte [] to String conversion
 				String webAddress = new String(
 						clientPacket.getData(),

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1752456450,
+        "lastModified": 1753742913,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e2a9d0dd4cf87a1801c6d9e0d7a57bdd6de26ace",
+        "rev": "55ae8928a82b53fda5e2b1c495901897d2c13b39",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -15,8 +15,6 @@ server: compile
 # Run the client
 client: compile
     @echo "Starting client..."
-    # Give the server a moment to start up
-    sleep 2
     java -cp bin JavaNetClientV2
 
 # Clean up compiled classes

--- a/justfile
+++ b/justfile
@@ -9,13 +9,13 @@ compile:
 # Run the server
 server: compile
     @echo "Starting server..."
-    java -cp bin NetServerV2
+    java -cp bin BLServer
     @echo "Server started in background."
 
 # Run the client
 client: compile
     @echo "Starting client..."
-    java -cp bin JavaNetClientV2
+    java -cp bin BLClient
 
 # Clean up compiled classes
 clean:


### PR DESCRIPTION
Use a single socket instead of instantiating a socket for every thread.

## Routing packets
To route a packet to the proper thread, I used a `ConcurrentHashMap` with a key of the client's port (this project is only meant to run within the same host machine) with its value of `clientHandler` that initialized it from

## Timeout implementation
To simulate a timeout, I used a `LinkedBlockingQueue`'s [poll](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/BlockingQueue.html#poll(long,%20java.util.concurrent.TimeUnit)) function with a parameter of `timeout` which waits until it returns an ACK packet that was queued in the main thread. 

If the timeout is reached, the `poll` function returns a `null` which tells the server to resend.

## Troubleshooting edge cases

### Chunks that aren't the last chunk

> This usually occurs on complex websites.

`byte[] payload = Arrays.copyOfRange(data, offset, offset + currentChunkSize);`

`payload` sometimes varies in size. In our client program, our initial check if we've received the last chunk was to compare if the payload length is less than the expected chunk size of 1024. This caused the client to close out it's socket prematurely, causing the server to resend packets into the void as the client is no longer listening.

I've added an integer `isLastChunk` to the datagram that the server sends to the client, initialized with a value of 0, to determine if the chunk being sent to the client is truly the last chunk. Modify the check on the client to see if `isLastChunk` has a value of 1, which then prompts the client to close its socket. 